### PR TITLE
Updated using Stadia Key

### DIFF
--- a/src/pages/DateTracking.tsx
+++ b/src/pages/DateTracking.tsx
@@ -507,11 +507,15 @@ useEffect(() => {
             attribution="&copy; OpenStreetMap contributors &copy; CARTO"
             url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
           />
-          */}
           <TileLayer
             attribution='&copy; OpenStreetMap contributors'
             url="https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png"
             noWrap={true}
+          />
+          */}
+          <TileLayer
+            url={`https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}{r}.png?api_key=${import.meta.env.VITE_STADIA_API_KEY}`}
+            attribution='&copy; Stadia Maps'
           />
 
           {position && (


### PR DESCRIPTION
Summary:

- Leaflet does not provide map imagery itself
- Leaflet needs a map tile provider to supply the actual map images that users see in the app.
- use Stadia Maps as our tile provider because it integrates well with Leaflet and provides the map tiles for our application.
- When Leaflet requests map tiles, those requests are sent to Stadia Maps.
- Stadia Maps requires an API key to authenticate and authorize those tile requests.